### PR TITLE
Add patch for nginx-1.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ How to install
 git clone https://github.com/nginx/nginx.git
 git clone https://github.com/alexzzh/ngx_health_detect_module.git
 cd nginx/;
-git checkout branches/stable-x.x.x
+git checkout branches/stable-x.yy
 
 //apply patch or adjust nginx code according to the patch file
-git apply ../ngx_health_detect_module/patch/nginx_healthdetect_for_nginx_x.xx+.patch
+patch -p1 <../ngx_health_detect_module/patch/nginx_healthdetect_for_nginx_x.yy+.patch
 
 auto/configure --with-stream --add-module=../ngx_health_detect_module
 make && make install

--- a/patch/nginx_healthdetect_for_nginx_1.24+.patch
+++ b/patch/nginx_healthdetect_for_nginx_1.24+.patch
@@ -1,0 +1,326 @@
+diff --git a/src/http/modules/ngx_http_upstream_hash_module.c b/src/http/modules/ngx_http_upstream_hash_module.c
+index e741eb23..7d42ac81 100644
+--- a/src/http/modules/ngx_http_upstream_hash_module.c
++++ b/src/http/modules/ngx_http_upstream_hash_module.c
+@@ -9,6 +9,10 @@
+ #include <ngx_core.h>
+ #include <ngx_http.h>
+ 
++#if (NGX_HTTP_HEALTH_DETECT)
++#include "ngx_http_health_detect_module.h"
++#endif
++
+ 
+ typedef struct {
+     uint32_t                            hash;
+@@ -238,6 +242,12 @@ ngx_http_upstream_get_hash_peer(ngx_peer_connection_t *pc, void *data)
+             goto next;
+         }
+ 
++#if (NGX_HTTP_HEALTH_DETECT)
++        if (ngx_http_health_detect_upstream_check_peer_down(hp->rrp.peers->name, &peer->server, &peer->name)) {
++            goto next;
++        }
++#endif
++
+         if (peer->max_fails
+             && peer->fails >= peer->max_fails
+             && now - peer->checked <= peer->fail_timeout)
+@@ -560,6 +570,12 @@ ngx_http_upstream_get_chash_peer(ngx_peer_connection_t *pc, void *data)
+                 continue;
+             }
+ 
++#if (NGX_HTTP_HEALTH_DETECT)
++            if (ngx_http_health_detect_upstream_check_peer_down(hp->rrp.peers->name, &peer->server, &peer->name)) {
++                continue;
++            }
++#endif
++
+             if (peer->server.len != server->len
+                 || ngx_strncmp(peer->server.data, server->data, server->len)
+                    != 0)
+diff --git a/src/http/modules/ngx_http_upstream_ip_hash_module.c b/src/http/modules/ngx_http_upstream_ip_hash_module.c
+index 1fa01d95..0b7560e1 100644
+--- a/src/http/modules/ngx_http_upstream_ip_hash_module.c
++++ b/src/http/modules/ngx_http_upstream_ip_hash_module.c
+@@ -9,6 +9,10 @@
+ #include <ngx_core.h>
+ #include <ngx_http.h>
+ 
++#if (NGX_HTTP_HEALTH_DETECT)
++#include "ngx_http_health_detect_module.h"
++#endif
++
+ 
+ typedef struct {
+     /* the round robin data must be first */
+@@ -208,6 +212,12 @@ ngx_http_upstream_get_ip_hash_peer(ngx_peer_connection_t *pc, void *data)
+             goto next;
+         }
+ 
++#if (NGX_HTTP_HEALTH_DETECT)
++        if (ngx_http_health_detect_upstream_check_peer_down(iphp->rrp.peers->name, &peer->server, &peer->name)) {
++            goto next;
++        }
++#endif
++
+         if (peer->max_fails
+             && peer->fails >= peer->max_fails
+             && now - peer->checked <= peer->fail_timeout)
+diff --git a/src/http/modules/ngx_http_upstream_least_conn_module.c b/src/http/modules/ngx_http_upstream_least_conn_module.c
+index ebe06276..a50541c4 100644
+--- a/src/http/modules/ngx_http_upstream_least_conn_module.c
++++ b/src/http/modules/ngx_http_upstream_least_conn_module.c
+@@ -9,6 +9,10 @@
+ #include <ngx_core.h>
+ #include <ngx_http.h>
+ 
++#if (NGX_HTTP_HEALTH_DETECT)
++#include "ngx_http_health_detect_module.h"
++#endif
++
+ 
+ static ngx_int_t ngx_http_upstream_init_least_conn_peer(ngx_http_request_t *r,
+     ngx_http_upstream_srv_conf_t *us);
+@@ -147,6 +151,12 @@ ngx_http_upstream_get_least_conn_peer(ngx_peer_connection_t *pc, void *data)
+             continue;
+         }
+ 
++#if (NGX_HTTP_HEALTH_DETECT)
++        if (ngx_http_health_detect_upstream_check_peer_down(rrp->peers->name, &peer->server, &peer->name)) {
++            continue;
++        }
++#endif
++
+         if (peer->max_fails
+             && peer->fails >= peer->max_fails
+             && now - peer->checked <= peer->fail_timeout)
+@@ -202,6 +212,12 @@ ngx_http_upstream_get_least_conn_peer(ngx_peer_connection_t *pc, void *data)
+                 continue;
+             }
+ 
++#if (NGX_HTTP_HEALTH_DETECT)
++            if (ngx_http_health_detect_upstream_check_peer_down(rrp->peers->name, &peer->server, &peer->name)) {
++                continue;
++            }
++#endif
++
+             if (peer->conns * best->weight != best->conns * peer->weight) {
+                 continue;
+             }
+diff --git a/src/http/ngx_http_upstream_round_robin.c b/src/http/ngx_http_upstream_round_robin.c
+index 1f15fae5..de81d9f9 100644
+--- a/src/http/ngx_http_upstream_round_robin.c
++++ b/src/http/ngx_http_upstream_round_robin.c
+@@ -9,6 +9,10 @@
+ #include <ngx_core.h>
+ #include <ngx_http.h>
+ 
++#if (NGX_HTTP_HEALTH_DETECT)
++#include "ngx_http_health_detect_module.h"
++#endif
++
+ 
+ #define ngx_http_upstream_tries(p) ((p)->tries                                \
+                                     + ((p)->next ? (p)->next->tries : 0))
+@@ -104,6 +108,12 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
+                 peer[n].down = server[i].down;
+                 peer[n].server = server[i].name;
+ 
++#if (NGX_HTTP_HEALTH_DETECT)
++                if (!server[i].down) {
++                    ngx_http_health_detect_upstream_add_peer(us, &server[i].name, &server[i].addrs[j]);
++                }
++#endif
++
+                 *peerp = &peer[n];
+                 peerp = &peer[n].next;
+                 n++;
+@@ -174,6 +184,12 @@ ngx_http_upstream_init_round_robin(ngx_conf_t *cf,
+                 peer[n].down = server[i].down;
+                 peer[n].server = server[i].name;
+ 
++#if (NGX_HTTP_HEALTH_DETECT)
++                if (!server[i].down) {
++                    ngx_http_health_detect_upstream_add_peer(us, &server[i].name, &server[i].addrs[j]);
++                }
++#endif
++
+                 *peerp = &peer[n];
+                 peerp = &peer[n].next;
+                 n++;
+@@ -457,6 +473,12 @@ ngx_http_upstream_get_round_robin_peer(ngx_peer_connection_t *pc, void *data)
+             goto failed;
+         }
+ 
++#if (NGX_HTTP_HEALTH_DETECT)
++        if (ngx_http_health_detect_upstream_check_peer_down(peers->name, &peer->server, &peer->name)) {
++            goto failed;
++        }
++#endif
++
+         rrp->current = peer;
+ 
+     } else {
+@@ -551,6 +573,12 @@ ngx_http_upstream_get_peer(ngx_http_upstream_rr_peer_data_t *rrp)
+             continue;
+         }
+ 
++#if (NGX_HTTP_HEALTH_DETECT)
++        if (ngx_http_health_detect_upstream_check_peer_down(rrp->peers->name, &peer->server, &peer->name)) {
++            continue;
++        }
++#endif
++
+         if (peer->max_fails
+             && peer->fails >= peer->max_fails
+             && now - peer->checked <= peer->fail_timeout)
+diff --git a/src/stream/ngx_stream_upstream_hash_module.c b/src/stream/ngx_stream_upstream_hash_module.c
+index b764fcbe..a2567135 100644
+--- a/src/stream/ngx_stream_upstream_hash_module.c
++++ b/src/stream/ngx_stream_upstream_hash_module.c
+@@ -9,6 +9,10 @@
+ #include <ngx_core.h>
+ #include <ngx_stream.h>
+ 
++#if (NGX_STREAM_HEALTH_DETECT)
++#include "ngx_stream_health_detect_module.h"
++#endif
++
+ 
+ typedef struct {
+     uint32_t                              hash;
+@@ -237,6 +241,12 @@ ngx_stream_upstream_get_hash_peer(ngx_peer_connection_t *pc, void *data)
+             goto next;
+         }
+ 
++#if (NGX_STREAM_HEALTH_DETECT)
++        if (ngx_stream_health_detect_upstream_check_peer_down(hp->rrp.peers->name, &peer->server, &peer->name)) {
++            goto next;
++        }
++#endif
++
+         if (peer->max_fails
+             && peer->fails >= peer->max_fails
+             && now - peer->checked <= peer->fail_timeout)
+@@ -550,6 +560,12 @@ ngx_stream_upstream_get_chash_peer(ngx_peer_connection_t *pc, void *data)
+                 continue;
+             }
+ 
++#if (NGX_STREAM_HEALTH_DETECT)
++            if (ngx_stream_health_detect_upstream_check_peer_down(hp->rrp.peers->name, &peer->server, &peer->name)) {
++                continue;
++            }
++#endif
++
+             if (peer->max_fails
+                 && peer->fails >= peer->max_fails
+                 && now - peer->checked <= peer->fail_timeout)
+diff --git a/src/stream/ngx_stream_upstream_least_conn_module.c b/src/stream/ngx_stream_upstream_least_conn_module.c
+index 739b20a9..439b9df6 100644
+--- a/src/stream/ngx_stream_upstream_least_conn_module.c
++++ b/src/stream/ngx_stream_upstream_least_conn_module.c
+@@ -9,6 +9,10 @@
+ #include <ngx_core.h>
+ #include <ngx_stream.h>
+ 
++#if (NGX_STREAM_HEALTH_DETECT)
++#include "ngx_stream_health_detect_module.h"
++#endif
++
+ 
+ static ngx_int_t ngx_stream_upstream_init_least_conn_peer(
+     ngx_stream_session_t *s, ngx_stream_upstream_srv_conf_t *us);
+@@ -143,6 +147,12 @@ ngx_stream_upstream_get_least_conn_peer(ngx_peer_connection_t *pc, void *data)
+             continue;
+         }
+ 
++#if (NGX_STREAM_HEALTH_DETECT)
++        if (ngx_stream_health_detect_upstream_check_peer_down(rrp->peers->name, &peer->server, &peer->name)) {
++            continue;
++        }
++#endif
++
+         if (peer->max_fails
+             && peer->fails >= peer->max_fails
+             && now - peer->checked <= peer->fail_timeout)
+@@ -198,6 +208,12 @@ ngx_stream_upstream_get_least_conn_peer(ngx_peer_connection_t *pc, void *data)
+                 continue;
+             }
+ 
++#if (NGX_STREAM_HEALTH_DETECT)
++            if (ngx_stream_health_detect_upstream_check_peer_down(rrp->peers->name, &peer->server, &peer->name)) {
++                continue;
++            }
++#endif
++
+             if (peer->conns * best->weight != best->conns * peer->weight) {
+                 continue;
+             }
+diff --git a/src/stream/ngx_stream_upstream_round_robin.c b/src/stream/ngx_stream_upstream_round_robin.c
+index ae3bf37a..88ee5d89 100644
+--- a/src/stream/ngx_stream_upstream_round_robin.c
++++ b/src/stream/ngx_stream_upstream_round_robin.c
+@@ -9,6 +9,10 @@
+ #include <ngx_core.h>
+ #include <ngx_stream.h>
+ 
++#if (NGX_STREAM_HEALTH_DETECT)
++#include "ngx_stream_health_detect_module.h"
++#endif
++
+ 
+ #define ngx_stream_upstream_tries(p) ((p)->tries                              \
+                                       + ((p)->next ? (p)->next->tries : 0))
+@@ -110,6 +114,12 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
+                 peer[n].down = server[i].down;
+                 peer[n].server = server[i].name;
+ 
++#if (NGX_STREAM_HEALTH_DETECT)
++                if (!server[i].down) {
++                    ngx_stream_health_detect_upstream_add_peer(us, &server[i].name, &server[i].addrs[j]);
++                }
++#endif
++
+                 *peerp = &peer[n];
+                 peerp = &peer[n].next;
+                 n++;
+@@ -180,6 +190,12 @@ ngx_stream_upstream_init_round_robin(ngx_conf_t *cf,
+                 peer[n].down = server[i].down;
+                 peer[n].server = server[i].name;
+ 
++#if (NGX_STREAM_HEALTH_DETECT)
++                if (!server[i].down) {
++                    ngx_stream_health_detect_upstream_add_peer(us, &server[i].name, &server[i].addrs[j]);
++                }
++#endif
++
+                 *peerp = &peer[n];
+                 peerp = &peer[n].next;
+                 n++;
+@@ -466,6 +482,12 @@ ngx_stream_upstream_get_round_robin_peer(ngx_peer_connection_t *pc, void *data)
+             goto failed;
+         }
+ 
++#if (NGX_STREAM_HEALTH_DETECT)
++        if (ngx_stream_health_detect_upstream_check_peer_down(peers->name, &peer->server, &peer->name)) {
++            goto failed;
++        }
++#endif
++
+         rrp->current = peer;
+ 
+     } else {
+@@ -571,6 +593,12 @@ ngx_stream_upstream_get_peer(ngx_stream_upstream_rr_peer_data_t *rrp)
+             continue;
+         }
+ 
++#if (NGX_STREAM_HEALTH_DETECT)
++        if (ngx_stream_health_detect_upstream_check_peer_down(rrp->peers->name, &peer->server, &peer->name)) {
++            continue;
++        }
++#endif
++
+         peer->current_weight += peer->effective_weight;
+         total += peer->effective_weight;
+ 


### PR DESCRIPTION
Moving to stable 1.24. This applies cleanly. Also suggest `patch` instead of `git apply` for installing. In my case git 2.17 failed to apply  a patch generated with git 2.40.