### PR TITLE
fix bug on not use upstream block

### DIFF
--- a/ngx_http_health_detect_module.c
+++ b/ngx_http_health_detect_module.c
@@ -2188,6 +2188,11 @@ ngx_http_health_detect_upstream_check_peer_down(
     ngx_health_detect_peer_shm_t *peer_shm;
     ngx_uint_t rc;
 
+    /* upstream server_name is empty when not use upstream block */
+    if (server_name->len == 0) {
+        return 0;
+    }
+
     temp_pool = ngx_create_pool(ngx_pagesize, ngx_cycle->log);
     full_name.len =
         upstream_name->len + server_name->len + peer_addr_name->len + 2;

--- a/ngx_stream_health_detect_module.c
+++ b/ngx_stream_health_detect_module.c
@@ -2200,6 +2200,11 @@ ngx_stream_health_detect_upstream_check_peer_down(
     ngx_health_detect_peer_shm_t *peer_shm;
     ngx_uint_t rc;
 
+   /* upstream server_name is empty when not use upstream block */
+    if (server_name->len == 0) {
+        return 0;
+    }
+
     temp_pool = ngx_create_pool(ngx_pagesize, ngx_cycle->log);
     full_name.len =
         upstream_name->len + server_name->len + peer_addr_name->len + 2;


### PR DESCRIPTION
### 相关issue
  - https://github.com/alexzzh/ngx_health_detect_module/issues/11
### 问题描述
  - 当不使用upstream块，直接在proxy_pass指令后使用ip:port时会导致查询节点状态时，状态无效

### 解决方案
  - 实际上，当不使用upstream块时，该模块应该不生效即可，所以不需要将对应节点加入到探测列表，该模块也不影响该节点的状态