### PR TITLE
Fix compilation error referencing 1.24+.patch in nginx-1.26 version

### DIFF
--- a/ngx_http_health_detect_module.c
+++ b/ngx_http_health_detect_module.c
@@ -684,7 +684,7 @@ ngx_http_health_detect_recv_handler(ngx_event_t *event)
             err = (size >= 0) ? 0 : ngx_socket_errno;
             ngx_log_error(NGX_LOG_DEBUG, c->log, err,
                 "http check recv size: %z, peer: %V ", size,
-                &peer->policy.peer_addr.name);
+                &peer->policy->peer_addr.name);
         }
 #endif
 

--- a/ngx_stream_health_detect_module.c
+++ b/ngx_stream_health_detect_module.c
@@ -679,7 +679,7 @@ ngx_stream_health_detect_recv_handler(ngx_event_t *event)
             ngx_err_t err;
 
             err = (size >= 0) ? 0 : ngx_socket_errno;
-            ngx_log_debug2(NGX_LOG_DEBUG_STREAM, c->log, 0,
+            ngx_log_debug2(NGX_LOG_DEBUG_STREAM, c->log, err,
                 "http check parse rc: %i, peer: %V ", rc,
                 &peer->policy->peer_addr.name);
         }

--- a/ngx_stream_health_detect_module.c
+++ b/ngx_stream_health_detect_module.c
@@ -677,7 +677,7 @@ ngx_stream_health_detect_recv_handler(ngx_event_t *event)
 #if (NGX_DEBUG)
         {
             ngx_err_t err;
-
+            rc = peer->default_policy->parse(peer);
             err = (size >= 0) ? 0 : ngx_socket_errno;
             ngx_log_debug2(NGX_LOG_DEBUG_STREAM, c->log, err,
                 "http check parse rc: %i, peer: %V ", rc,


### PR DESCRIPTION
重新制作1.26的补丁脚本实在不知道如何搞定(C命令都忘光了), 直接在nginx-1.26版本中引用了patch中的1.24+补丁,但是编译有一些报错，根据报错信息提示大致找到了相对的文件并做了修复，以上，感谢。