### PR TITLE
解决内存使用上的一些问题

### DIFF
--- a/ngx_stream_health_detect_module.c
+++ b/ngx_stream_health_detect_module.c
@@ -49,6 +49,8 @@ static ngx_int_t ngx_stream_health_detect_status_update(
 
 static ngx_int_t ngx_stream_health_detect_add_timer(ngx_rbtree_node_t *node);
 static ngx_int_t ngx_stream_health_detect_init_process(ngx_cycle_t *cycle);
+static void ngx_stream_health_detect_exit_process(ngx_cycle_t *cycle);
+static void ngx_stream_health_detect_exit_master(ngx_cycle_t *cycle);
 static ngx_int_t ngx_stream_health_detect_need_exit();
 
 static void ngx_stream_health_detect_clean_timeout_event_and_connection(
@@ -85,6 +87,8 @@ static char *ngx_stream_health_detect_http_send(
     ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static char *ngx_stream_health_detect_http_expect_alive(
     ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+
+static void ngx_stream_health_detect_clear_peers_events();
 
 static ngx_conf_bitmask_t ngx_check_http_expect_alive_masks[] = {
     {ngx_string("http_2xx"), NGX_CHECK_HTTP_2XX},
@@ -141,14 +145,14 @@ static ngx_stream_module_t ngx_stream_health_detect_modules_ctx = {NULL, NULL,
 ngx_module_t ngx_stream_health_detect_module = {NGX_MODULE_V1,
     &ngx_stream_health_detect_modules_ctx, ngx_stream_health_detect_cmds,
     NGX_STREAM_MODULE, NULL, NULL, ngx_stream_health_detect_init_process, NULL,
-    NULL, NULL, NULL, NGX_MODULE_V1_PADDING};
+    NULL, ngx_stream_health_detect_exit_process, ngx_stream_health_detect_exit_master, NGX_MODULE_V1_PADDING};
 
 static void *
 ngx_stream_health_detect_create_main_conf(ngx_conf_t *cf)
 {
     ngx_stream_health_detect_main_conf_t *hdmcf;
     ngx_health_detect_peers_t *peers;
-
+    ngx_stream_health_detect_clear_peers_events();
     hdmcf = ngx_pcalloc(cf->pool, sizeof(ngx_stream_health_detect_main_conf_t));
     if (hdmcf == NULL) {
         return NULL;
@@ -823,7 +827,9 @@ ngx_stream_health_detect_clear_peers_events()
 
     ngx_log_debug1(NGX_LOG_DEBUG_STREAM, ngx_cycle->log, 0,
         "clear all the events on %P ", ngx_pid);
-
+    if (peers_manager_ctx == NULL || peers_manager_ctx->peers == NULL) {
+        return;
+    }
     peers = peers_manager_ctx->peers;
 
     node = peers->rbtree.root;
@@ -1124,7 +1130,7 @@ ngx_stream_health_detect_shm_free_node(ngx_rbtree_node_t *node)
 
     peers_shm = peers_manager_ctx->peers_shm;
     shpool = peers_shm->shpool;
-
+    peers_shm->checksum -= peer_shm->policy.checksum;
     if (peer_shm->policy.peer_name.data != NULL) {
         ngx_slab_free_locked(shpool, peer_shm->policy.peer_name.data);
     }
@@ -1437,12 +1443,12 @@ ngx_stream_health_detect_add_or_update_node_on_local(
     return NGX_OK;
 
 failed:
+    ngx_log_error(NGX_LOG_INFO, ngx_cycle->log, 0,
+        "on local: op(add/update) node key(%V) failed", &policy->peer_name);
     if (node) {
         ngx_stream_health_detect_free_node(node);
     }
 
-    ngx_log_error(NGX_LOG_INFO, ngx_cycle->log, 0,
-        "on local: op(add/update) node key(%V) failed", &policy->peer_name);
 
     return NGX_ERROR;
 }
@@ -1616,11 +1622,11 @@ ngx_stream_health_detect_status_update(
         node->key, &peer->policy->peer_name);
     if (node_shm == NULL) {
         ngx_shmtx_unlock(&shpool->mutex);
-        ngx_stream_health_detect_free_node(node);
         ngx_log_error(NGX_LOG_INFO, ngx_cycle->log, 0,
             "on status update:peer name(%V) not exit in shm, so needn't "
             "update status",
             &peer->policy->peer_name);
+        ngx_stream_health_detect_free_node(node);
 
         return NGX_DONE;
     }
@@ -1628,12 +1634,11 @@ ngx_stream_health_detect_status_update(
     peer_shm = (ngx_health_detect_peer_shm_t *) &node_shm->color;
     if (peer_shm->policy.checksum != peer->policy->checksum) {
         ngx_shmtx_unlock(&shpool->mutex);
-        ngx_stream_health_detect_free_node(node);
-
         ngx_log_error(NGX_LOG_INFO, ngx_cycle->log, 0,
             "on status update:peer name(%V) exit in shm but policy is "
             "diff, so needn't update status",
             &peer->policy->peer_name);
+        ngx_stream_health_detect_free_node(node);
 
         return NGX_DONE;
     }
@@ -1842,12 +1847,12 @@ ngx_stream_health_detect_start_check_handler(ngx_event_t *event)
         node->key, &peer->policy->peer_name);
     if (node_shm == NULL) {
         ngx_shmtx_unlock(&shpool->mutex);
-        ngx_stream_health_detect_free_node(node);
-
         ngx_log_error(NGX_LOG_INFO, ngx_cycle->log, 0,
             "on start check handler: peer name(%V) not exit in shm, "
             "needn't check again",
             &peer->policy->peer_name);
+        ngx_stream_health_detect_free_node(node);
+
         return;
     }
 
@@ -2520,4 +2525,15 @@ ngx_stream_health_detect_init_process(ngx_cycle_t *cycle)
         return rc;
     }
     return ngx_stream_health_detect_add_reload_shm_timer(cycle);
+}
+
+static void
+ngx_stream_health_detect_exit_process(ngx_cycle_t *cycle)
+{
+    ngx_stream_health_detect_clear_peers_events();
+}
+
+static void ngx_stream_health_detect_exit_master(ngx_cycle_t *cycle)
+{    
+    ngx_stream_health_detect_clear_peers_events();
 }


### PR DESCRIPTION
1. master进程中调用了ngx_http_health_detect_add_or_update_node_on_local，并创建了内存池 temp_pool = ngx_create_pool(...); 当reload nginx时，这部分内存分配的node节点不会释放，会继续创建新的内存池，继续新的分配。解决办法是在ngx_http_health_detect_create_main_conf中调用ngx_http_health_detect_clear_peers_events进行释放内存
2. 先打印相关信息，再进行free_node，避免内存释放后还继续使用