### PR TITLE
如果未配置健康检查的情况，如果rc返回1，代表健康检查失败，此时无法选择正确的后端，应该返回0，更符合nginx的使用

### DIFF
--- a/ngx_http_health_detect_module.c
+++ b/ngx_http_health_detect_module.c
@@ -2215,7 +2215,7 @@ ngx_http_health_detect_upstream_check_peer_down(
             "check http upstream peer(%V) down flag(%ui)", &full_name, rc);
 
     } else {
-        rc = 1;
+        rc = 0;
         ngx_log_error(NGX_LOG_INFO, ngx_cycle->log, 0,
             "check http upstream peer(%V) not found, down flag(%ui)",
             &full_name, rc);

--- a/ngx_stream_health_detect_module.c
+++ b/ngx_stream_health_detect_module.c
@@ -2229,7 +2229,7 @@ ngx_stream_health_detect_upstream_check_peer_down(
             "check stream upstream peer(%V) down flag(%ui)", &full_name, rc);
 
     } else {
-        rc = 1;
+        rc = 0;
         ngx_log_error(NGX_LOG_INFO, ngx_cycle->log, 0,
             "check stream upstream peer(%V) not found, down flag(%ui)",
             &full_name, rc);


### PR DESCRIPTION
如果未配置健康检查的情况，如果rc返回1，代表健康检查失败，此时无法选择正确的后端，应该返回0，更符合nginx的使用